### PR TITLE
Fixes to RawReader

### DIFF
--- a/ultratils/pysonix/scanconvert.pyx
+++ b/ultratils/pysonix/scanconvert.pyx
@@ -134,16 +134,6 @@ probe = Probe object
             frame = frame of unconverted bpr or raw data
         """
         self._fan[:] = 0
-        if self._fan.dtype != frame.dtype:
-            self._fan = self._fan.astype(frame.dtype)
-        self._fan.ravel()[self.bmp_index] = frame.ravel()[self.bpr_index]
-        return self._fan.astype(frame.dtype, copy=False)
-
-    def convert_flip(self, frame):
-        """
-            In testing: same as convert, but doesn't need multiple np.flipud()
-        """
-        self._fan[:] = 0
         frame = np.flipud(frame)
         if self._fan.dtype != frame.dtype:
             self._fan = self._fan.astype(frame.dtype)

--- a/ultratils/pysonix/scanconvert.pyx
+++ b/ultratils/pysonix/scanconvert.pyx
@@ -127,17 +127,6 @@ probe = Probe object
         points = np.zeros(self._fan.shape, dtype=NPLONG) * np.nan
         points.ravel()[theta]
         return points
-    
-    def convert(self, frame):
-        """
-            Return unconverted raw data frame as a converted bitmap.
-            frame = frame of unconverted data
-        """
-        self._fan[:] = 0
-        if self._fan.dtype != frame.dtype:
-            self._fan = self._fan.astype(frame.dtype)
-        self._fan.ravel()[self.bmp_index] = frame.ravel()[self.bpr_index]
-        return self._fan.astype(frame.dtype, copy=False)
 
     def convert(self, frame):
         """

--- a/ultratils/pysonix/scanconvert.pyx
+++ b/ultratils/pysonix/scanconvert.pyx
@@ -139,6 +139,17 @@ probe = Probe object
         self._fan.ravel()[self.bmp_index] = frame.ravel()[self.bpr_index]
         return self._fan.astype(frame.dtype, copy=False)
 
+    def convert_flip(self, frame):
+        """
+            In testing: same as convert, but doesn't need multiple np.flipud()
+        """
+        self._fan[:] = 0
+        frame = np.flipud(frame)
+        if self._fan.dtype != frame.dtype:
+            self._fan = self._fan.astype(frame.dtype)
+        self._fan.ravel()[self.bmp_index] = frame.ravel()[self.bpr_index]
+        return np.flipud(self._fan.astype(frame.dtype, copy=False))
+
     def as_bmp(self, frame):
         """
             Deprecated. Return bpr frame data as a converted bitmap.

--- a/ultratils/pysonix/scanconvert.pyx
+++ b/ultratils/pysonix/scanconvert.pyx
@@ -134,11 +134,10 @@ probe = Probe object
             frame = frame of unconverted bpr or raw data
         """
         self._fan[:] = 0
-        frame = np.flipud(frame)
         if self._fan.dtype != frame.dtype:
             self._fan = self._fan.astype(frame.dtype)
         self._fan.ravel()[self.bmp_index] = frame.ravel()[self.bpr_index]
-        return np.flipud(self._fan.astype(frame.dtype, copy=False))
+        return self._fan.astype(frame.dtype, copy=False)
 
     def as_bmp(self, frame):
         """

--- a/ultratils/rawreader.py
+++ b/ultratils/rawreader.py
@@ -84,7 +84,10 @@ data_offset=0, checksum=False):
             data = np.fromfile(self._fhandle, self.dtype)
             self._fhandle.seek(self._cursor)
             imdims = [self.nframes, self.nscanlines, self.npoints]
-            self._data = np.rot90(data.reshape(imdims), axes=(1, 2))
+            try:
+                self._data = np.rot90(data.reshape(imdims), axes=(1, 2))
+            except TypeError: # numpy < v1.12
+                self._data = np.array([np.rot90(fr) for fr in data.reshape(imdims)])
         return self._data
 
     @property


### PR DESCRIPTION
Fixes to RawReader.data() provide functionality for old versions of numpy (v<1.12), which are required to run some important libraries (namely OpenCV) on Python 3.x.